### PR TITLE
Resolução do bug ao deletar eventos pelo front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.metadata/

--- a/FrontEnd/JavascripFunciona.js
+++ b/FrontEnd/JavascripFunciona.js
@@ -28,15 +28,16 @@ async function deletarEvento(eventoId) {
                 throw new Error(`Erro ao deletar evento: ${response.status}`);
             }
             console.log(`Evento ${eventoId} deletado com sucesso.`);
-            // Atualiza a lista de eventos após a exclusão
-            const eventosAtualizados = await getEventos();
-            exibirEventos(eventosAtualizados);
+            // Recarrega a página após a exclusão bem-sucedida
+            alert("Evento deletado com sucesso!"); // Alerta de sucesso antes de recarregar
+            window.location.reload(); // Recarrega a página para atualizar a lista de eventos
         } catch (error) {
             console.error(`Erro: ${error.message}`);
             alert("Erro ao deletar o evento. Tente novamente mais tarde."); // Mensagem ao usuário
         }
     }
 }
+
 
 // Função para exibir eventos na página
 function exibirEventos(eventos) {

--- a/FrontEnd/scripts.js
+++ b/FrontEnd/scripts.js
@@ -32,6 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
         .then(response => {
             if (response.ok) {
                 alert("Evento criado com sucesso!");
+                window.location.reload(); // Recarrega a página
                 return response.json();
             } else {
                 throw new Error("Erro ao criar o evento");


### PR DESCRIPTION
Resolução do bug ao deletar os eventos pelo front-end, que mesmo após o evento ser deletado ele ainda permanecia visível só desaparecendo após recarregar a página manualmente.